### PR TITLE
Correct documentation regarding protected fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,5 +189,5 @@ As default `ParcelablePlease` will throw a compile error if it tries to serializ
  ```
      
 # Limitations
- - **Fields** must have at least default (package) visibility. That means private or protected fields are not supported.
+ - **Fields** must have at least default (package) visibility. That means private fields are not supported.
  - **Private classes** are not supported because of visibilitiy issues


### PR DESCRIPTION
Protected things have the same visibility as package private + visible in subclasses.